### PR TITLE
docs: add issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,32 @@
+name: 🐞 Bug Report
+description: File a bug report
+title: "[Bug]: "
+type: "Bug"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for stopping by to let us know something could be better!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us what you expected to happen and how to reproduce the issue.
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our Code of Conduct
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/enhancement-proposal.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-proposal.md
@@ -1,0 +1,112 @@
+---
+name: Enhancement Proposal
+about: This is a template for submitting an enhancement proposal.
+title: Descriptive Title of the Enhancement
+labels: ''
+assignees: ''
+
+---
+
+## Summary
+
+<!--
+A 1-2 paragraph "elevator pitch" of the enhancement. It should be understandable
+to someone familiar with UCP but not necessarily the deep technical details of
+this specific proposal.
+-->
+
+## Motivation
+
+<!--
+Explain the problem this proposal solves. Why is this significant change
+necessary now? What use cases does it enable? Who is the target user or
+beneficiary of this change?
+-->
+
+### Goals
+
+<!--
+List the specific, measurable outcomes of this enhancement.
+-->
+*
+*
+
+### Non-Goals
+
+<!--
+Explicitly state what is out of scope for this proposal. This helps focus the
+discussion and prevents scope creep.
+-->
+*
+*
+
+## Detailed Design
+
+<!--
+This is the core of the proposal. Describe the architecture and implementation
+details with enough clarity that another contributor could write the code based
+on this description. Include sub-sections as needed, such as:
+
+* **API Changes:** Detail any new API endpoints, changes to existing ones, or
+  modifications to request/response schemas.
+* **Data Structures:** Describe any changes to core data structures or JSON
+  schemas.
+* **Behavioral Changes:** Explain how the system's fundamental behavior will
+  change.
+-->
+
+## Risks and Mitigations
+
+<!--
+This is a mandatory section. Discuss the potential downsides and risks of this
+proposal. For every risk identified, list a mitigation strategy.
+
+* **Security:** Does this introduce new attack vectors or data exposure risks?
+* **Performance:** Will this negatively impact latency or throughput?
+* **Backward Compatibility:** Will this break existing clients or workflows? If
+  so, what is the migration plan?
+* **Complexity:** Does this add significant maintenance burden to the protocol?
+-->
+
+## Test Plan
+
+<!--
+Describe how this feature will be tested. A test plan is required for a proposal
+to be moved to the "Provisional" stage.
+
+* **Unit Tests:** Which core logic requires unit coverage?
+* **Integration Tests:** How will interactions between different components be
+  verified?
+* **End-to-End Tests:** What user scenarios will be automated to validate the
+  full workflow?
+-->
+
+## Graduation Criteria
+
+<!--
+Define the specific, objective criteria required to move this capability through
+the maturity levels. See CONTRIBUTING.md for full definitions of each level.
+
+**Working Draft → Candidate:**
+* [ ] Schema merged and documented (with Working Draft disclaimer).
+* [ ] Unit and integration tests are passing.
+* [ ] Initial documentation is written.
+* [ ] TC majority vote to advance.
+
+**Candidate → Stable:**
+* [ ] Adoption feedback has been collected and addressed.
+* [ ] Full documentation and migration guides are published.
+* [ ] TC majority vote to advance.
+-->
+
+### Implementation History
+
+<!--
+This section will be updated by the maintainers as the proposal moves through
+its lifecycle.
+
+* [YYYY-MM-DD]: Proposal submitted.
+* [YYYY-MM-DD]: TC approved "Provisional"; capability enters "Working Draft".
+* [YYYY-MM-DD]: TC approved advancement to "Candidate".
+* [YYYY-MM-DD]: TC approved "Implemented"; capability enters "Stable".
+-->

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,40 @@
+name: 💡 Feature Request
+description: Suggest an idea for this repository
+title: "[Feat]: "
+type: "Feature"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for stopping by to let us know something could be better!
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your feature request related to a problem? Please describe.
+      description: A clear and concise description of what the problem is.
+      placeholder: Ex. I'm always frustrated when [...]
+  - type: textarea
+    id: describe
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our Code of Conduct
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Description


This PR moves templates from ucp repository to org level to share across all repositories . 
These templates ensure that contributors provide the necessary information (steps to reproduce, expected behavior, technical rationale) when filing bugs or proposing new features.

Key Changes

   * Added .github/ISSUE_TEMPLATE/ folder containing:
       * Bug Report (.md and .yml forms): For standardized bug tracking.
       * Feature Request (.md and .yml forms): For new capability suggestions.
       * Enhancement Proposal (.md): For technical RFCs and protocol changes.

  Category (Required)

   - [x] Infrastructure: CI/CD, Linters, or build scripts.
   - [x] Maintenance: Version bumps, lockfile updates, or minor bug fixes.

  Related Issues

  This is the foundational PR for establishing organization-wide health files and automation.

  Checklist

   - x] I have followed the [Contributing Guide (https://github.com/agentic-commerce/ucp/blob/main/CONTRIBUTING.md).
   - [ ] I have updated the documentation (if applicable).
   - [x] My changes pass all local linting and formatting checks (verified via pre-commit).
   - [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
   - [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.