### PR TITLE
feat: add discussion moderation agent

### DIFF
--- a/agents/discussion_moderation_agent/agent.py
+++ b/agents/discussion_moderation_agent/agent.py
@@ -1,0 +1,101 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from discussion_moderation_agent.settings import IS_INTERACTIVE
+from discussion_moderation_agent.settings import OWNER
+from discussion_moderation_agent.settings import REPO
+from discussion_moderation_agent.settings import TEAM_NAME
+from discussion_moderation_agent.tools import add_label_to_discussion
+from discussion_moderation_agent.tools import get_discussion_and_comments
+from google.adk.agents.llm_agent import Agent
+
+if IS_INTERACTIVE:
+    APPROVAL_INSTRUCTION = "Ask for user approval or confirmation for adding labels."
+else:
+    APPROVAL_INSTRUCTION = (
+        "**Do not** wait or ask for user approval or confirmation for adding labels."
+    )
+
+CODE_OF_CONDUCT = """
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+    advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+    address, without explicit permission
+* Disrespecting the community's time by sending spam or other unsolicited
+    commercial messages
+* Other conduct which could reasonably be considered inappropriate in a
+    professional setting
+"""
+
+root_agent = Agent(
+    model="gemini-1.5-flash",
+    name="discussion_moderation_agent",
+    description="Moderate GitHub discussions based on Lazy Involvement philosophy.",
+    instruction=f"""
+You are a discussion moderation bot for the GitHub {REPO} repo with the owner {OWNER}.
+Your goal is to foster peer-to-peer interaction, and only intervene when strictly necessary
+by flagging discussions that require maintainer attention.
+You should only flag discussions based on specific triggers.
+IMPORTANT: {APPROVAL_INSTRUCTION}
+
+## Rules for Flagging
+
+If any of the following triggers are met, you must flag the discussion by adding
+the label "needs-review". If multiple triggers are met, you only need to add
+the label once. Do NOT add comments to the discussion.
+
+### Triggers:
+
+1.  **Direct Mention**: A user tags a maintainer or @{TEAM_NAME}.
+    -   **Condition**: Check if any comment in the discussion contains "@<maintainer_username>" or "@{TEAM_NAME}" and asks for maintainer input or attention.
+
+2.  **Conversation Derailment**: Discussion promotes non-standard implementations, is off-topic, or includes unproductive debates.
+    -   **Condition**: The discussion meets any of the following:
+        -   **Spec Deviation**: It promotes "workarounds" or implementations that fundamentally break the UCP specification.
+        -   **Off-Topic**: It spirals into 'feature creep' or requests for things the protocol isn't designed to do.
+        -   **Unproductive Debate**: An unproductive debate is one where participants repeat the same arguments without providing new technical information or evidence, the discussion devolves into opinion without grounding in the specification or use cases, or it becomes circular without reaching a resolution.
+
+3.  **CoC Violations**: A comment includes spam, harassment, or abuse.
+    -   **Condition**: If a comment contains language or behavior that violates the Code of Conduct. Use the provided CoC standards to make this determination.
+    -   **Code of Conduct Standards**:
+        {CODE_OF_CONDUCT}
+
+## Workflow
+
+For each discussion you are asked to process:
+1. Use `get_discussion_and_comments` to fetch discussion details if not provided.
+2. Analyze discussion title, body, and all comments to check if any of the triggers (Direct Mention, Conversation Derailment, CoC Violation) are met.
+3. If one or more triggers are met, use the `add_label_to_discussion` tool to apply the label "needs-review" to the discussion.
+4. If no triggers are met, do nothing and report that no action is required for this discussion.
+""",
+    tools=[
+        get_discussion_and_comments,
+        add_label_to_discussion,
+    ],
+)

--- a/agents/discussion_moderation_agent/agent.py
+++ b/agents/discussion_moderation_agent/agent.py
@@ -20,12 +20,16 @@ from discussion_moderation_agent.tools import add_label_to_discussion
 from discussion_moderation_agent.tools import get_discussion_and_comments
 from google.adk.agents.llm_agent import Agent
 
+import datetime
+
 if IS_INTERACTIVE:
     APPROVAL_INSTRUCTION = "Ask for user approval or confirmation for adding labels."
 else:
     APPROVAL_INSTRUCTION = (
         "**Do not** wait or ask for user approval or confirmation for adding labels."
     )
+
+CURRENT_DATE = datetime.datetime.now().strftime("%Y-%m-%d")
 
 CODE_OF_CONDUCT = """
 ## Our Standards
@@ -64,6 +68,8 @@ by flagging discussions that require maintainer attention.
 You should only flag discussions based on specific triggers.
 IMPORTANT: {APPROVAL_INSTRUCTION}
 
+Today's date is {CURRENT_DATE}.
+
 ## Rules for Flagging
 
 If any of the following triggers are met, you must flag the discussion by adding
@@ -86,11 +92,14 @@ the label once. Do NOT add comments to the discussion.
     -   **Code of Conduct Standards**:
         {CODE_OF_CONDUCT}
 
+4.  **Stalled Q&A**: A Q&A discussion remains unanswered for a significant period.
+    -   **Condition**: The discussion is in an answerable category (e.g., "Q&A"), does NOT have an accepted answer (`answer` is null), and has had no new activity (comments or creation) for more than 1 month from {CURRENT_DATE}.
+
 ## Workflow
 
 For each discussion you are asked to process:
 1. Use `get_discussion_and_comments` to fetch discussion details if not provided.
-2. Analyze discussion title, body, and all comments to check if any of the triggers (Direct Mention, Conversation Derailment, CoC Violation) are met.
+2. Analyze discussion title, body, and all comments to check if any of the triggers (Direct Mention, Conversation Derailment, CoC Violation, Stalled Q&A) are met.
 3. If one or more triggers are met, use the `add_label_to_discussion` tool to apply the label "needs-review" to the discussion.
 4. If no triggers are met, do nothing and report that no action is required for this discussion.
 """,

--- a/agents/discussion_moderation_agent/agent.py
+++ b/agents/discussion_moderation_agent/agent.py
@@ -54,7 +54,7 @@ Examples of unacceptable behavior by participants include:
 """
 
 root_agent = Agent(
-    model="gemini-1.5-flash",
+    model="gemini-2.0-flash",
     name="discussion_moderation_agent",
     description="Moderate GitHub discussions based on Lazy Involvement philosophy.",
     instruction=f"""

--- a/agents/discussion_moderation_agent/main.py
+++ b/agents/discussion_moderation_agent/main.py
@@ -1,0 +1,191 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import asyncio
+import logging
+import sys
+import time
+from typing import Union
+
+from discussion_moderation_agent import agent
+from discussion_moderation_agent.settings import DISCUSSION_NUMBER
+from discussion_moderation_agent.settings import EVENT_NAME
+from discussion_moderation_agent.settings import OWNER
+from discussion_moderation_agent.settings import REPO
+from discussion_moderation_agent.utils import call_agent_async
+from discussion_moderation_agent.utils import parse_number_string
+from discussion_moderation_agent.utils import run_graphql_query
+from google.adk.cli.utils import logs
+from google.adk.runners import InMemoryRunner
+import requests
+
+APP_NAME = "discussion_moderation_app"
+USER_ID = "discussion_moderation_user"
+
+logs.setup_adk_logger(level=logging.INFO)
+
+
+async def list_all_open_discussions() -> Union[list[int], None]:
+    """Fetches all open discussions using pagination.
+
+    Returns:
+        A list of discussion numbers.
+    """
+    print(f"Attempting to fetch all open discussions from {OWNER}/{REPO}...")
+    query = """
+    query($owner: String!, $repo: String!, $count: Int!, $after: String) {
+      repository(owner: $owner, name: $repo) {
+        discussions(
+          first: $count
+          after: $after
+          orderBy: {field: UPDATED_AT, direction: DESC}
+          states: [OPEN]
+        ) {
+          nodes {
+            number
+          }
+          pageInfo {
+            endCursor
+            hasNextPage
+          }
+        }
+      }
+    }
+    """
+    all_discussion_numbers = []
+    has_next_page = True
+    end_cursor = None
+    try:
+        while has_next_page:
+            variables = {
+                "owner": OWNER,
+                "repo": REPO,
+                "count": 100,
+                "after": end_cursor,
+            }
+            response = run_graphql_query(query, variables)
+
+            if "errors" in response:
+                print(f"Error from GitHub API: {response['errors']}", file=sys.stderr)
+                return None
+
+            discussions_data = (
+                response.get("data", {}).get("repository", {}).get("discussions", {})
+            )
+            nodes = discussions_data.get("nodes", [])
+            all_discussion_numbers.extend([d["number"] for d in nodes])
+
+            page_info = discussions_data.get("pageInfo", {})
+            has_next_page = page_info.get("hasNextPage", False)
+            end_cursor = page_info.get("endCursor")
+
+        return all_discussion_numbers
+    except requests.exceptions.RequestException as e:
+        print(f"Request failed: {e}", file=sys.stderr)
+        return None
+
+
+def process_arguments():
+    """Parses command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="A script that moderates GitHub discussions.",
+        epilog=(
+            "Example usage: \n"
+            "\tpython -m discussion_moderation_agent.main --recent 10\n"
+            "\tpython -m discussion_moderation_agent.main --discussion_number 21\n"
+        ),
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+
+    group = parser.add_mutually_exclusive_group(required=True)
+
+    group.add_argument(
+        "--recent",
+        type=int,
+        metavar="COUNT",
+        help="Moderate the N most recently updated discussion numbers.",
+    )
+
+    group.add_argument(
+        "--discussion_number",
+        type=str,
+        metavar="NUM",
+        help="Moderate a specific discussion number.",
+    )
+
+    return parser.parse_args()
+
+
+async def main():
+    discussion_numbers_to_process = []
+    if EVENT_NAME == "discussion" and DISCUSSION_NUMBER:
+        print(f"EVENT: Processing specific discussion due to '{EVENT_NAME}' event.")
+        discussion_number = parse_number_string(DISCUSSION_NUMBER)
+        if not discussion_number:
+            print(f"Error: Invalid discussion number received: {DISCUSSION_NUMBER}.")
+            return
+        discussion_numbers_to_process = [discussion_number]
+    elif EVENT_NAME == "workflow_dispatch" and DISCUSSION_NUMBER:
+        print(f"EVENT: Processing specific discussion due to '{EVENT_NAME}' event.")
+        discussion_number = parse_number_string(DISCUSSION_NUMBER)
+        if not discussion_number:
+            print(f"Error: Invalid discussion number received: {DISCUSSION_NUMBER}.")
+            return
+        discussion_numbers_to_process = [discussion_number]
+    else:
+        print(f"EVENT: Processing batch of discussions (event: {EVENT_NAME}).")
+        fetched_numbers = await list_all_open_discussions()
+        if not fetched_numbers:
+            print("No discussions found matching criteria. Exiting...")
+            return
+        discussion_numbers_to_process = fetched_numbers
+
+    print(f"Will try to moderate discussions: {discussion_numbers_to_process}...")
+
+    runner = InMemoryRunner(
+        agent=agent.root_agent,
+        app_name=APP_NAME,
+    )
+
+    for discussion_number in discussion_numbers_to_process:
+        if len(discussion_numbers_to_process) > 1:
+            print("#" * 80)
+            print(f"Starting to process discussion #{discussion_number}...")
+        # Create a new session for each discussion to avoid interference.
+        session = await runner.session_service.create_session(
+            app_name=APP_NAME, user_id=USER_ID
+        )
+
+        prompt = f"Please moderate GitHub discussion #{discussion_number}."
+
+        response = await call_agent_async(runner, USER_ID, session.id, prompt)
+        print(f"<<<< Agent Final Output: {response}\n")
+
+
+if __name__ == "__main__":
+    start_time = time.time()
+    print(
+        f"Start discussion moderation on {OWNER}/{REPO} at"
+        f" {time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(start_time))}"
+    )
+    print("-" * 80)
+    asyncio.run(main())
+    print("-" * 80)
+    end_time = time.time()
+    print(
+        "Discussion moderation finished at"
+        f" {time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(end_time))}",
+    )
+    print("Total script execution time:", f"{end_time - start_time:.2f} seconds")

--- a/agents/discussion_moderation_agent/settings.py
+++ b/agents/discussion_moderation_agent/settings.py
@@ -1,0 +1,38 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv(override=True)
+
+GITHUB_BASE_URL = "https://api.github.com"
+GITHUB_GRAPHQL_URL = GITHUB_BASE_URL + "/graphql"
+
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
+if not GITHUB_TOKEN:
+    raise ValueError("GITHUB_TOKEN environment variable not set")
+
+GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY")
+if not GOOGLE_API_KEY:
+    raise ValueError("GOOGLE_API_KEY environment variable not set")
+
+OWNER = os.getenv("OWNER")
+REPO = os.getenv("REPO")
+EVENT_NAME = os.getenv("EVENT_NAME")
+DISCUSSION_NUMBER = os.getenv("DISCUSSION_NUMBER")
+
+IS_INTERACTIVE = os.environ.get("INTERACTIVE", "0").lower() in ["true", "1"]
+TEAM_NAME = "Universal-Commerce-Protocol/maintainers"

--- a/agents/discussion_moderation_agent/tools.py
+++ b/agents/discussion_moderation_agent/tools.py
@@ -34,6 +34,16 @@ def get_discussion_and_comments(discussion_number: int) -> dict[str, Any]:
           id
           title
           body
+          createdAt
+          updatedAt
+          category {
+            name
+            isAnswerable
+          }
+          answer {
+            id
+            createdAt
+          }
           author {
             login
           }

--- a/agents/discussion_moderation_agent/tools.py
+++ b/agents/discussion_moderation_agent/tools.py
@@ -1,0 +1,38 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv(override=True)
+
+GITHUB_BASE_URL = "https://api.github.com"
+GITHUB_GRAPHQL_URL = GITHUB_BASE_URL + "/graphql"
+
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
+if not GITHUB_TOKEN:
+    raise ValueError("GITHUB_TOKEN environment variable not set")
+
+GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY")
+if not GOOGLE_API_KEY:
+    raise ValueError("GOOGLE_API_KEY environment variable not set")
+
+OWNER = os.getenv("OWNER")
+REPO = os.getenv("REPO")
+EVENT_NAME = os.getenv("EVENT_NAME")
+DISCUSSION_NUMBER = os.getenv("DISCUSSION_NUMBER")
+
+IS_INTERACTIVE = os.environ.get("INTERACTIVE", "0").lower() in ["true", "1"]
+TEAM_NAME = "Universal-Commerce-Protocol/maintainers"

--- a/agents/discussion_moderation_agent/tools.py
+++ b/agents/discussion_moderation_agent/tools.py
@@ -12,27 +12,131 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
+import requests
+from typing import Any
+from discussion_moderation_agent.settings import OWNER, REPO, GITHUB_BASE_URL
+from discussion_moderation_agent.utils import run_graphql_query, error_response, headers
 
-from dotenv import load_dotenv
+def get_discussion_and_comments(discussion_number: int) -> dict[str, Any]:
+    """Fetches a discussion's title, body, and comments.
 
-load_dotenv(override=True)
+    Args:
+        discussion_number: The number of the GitHub discussion.
 
-GITHUB_BASE_URL = "https://api.github.com"
-GITHUB_GRAPHQL_URL = GITHUB_BASE_URL + "/graphql"
+    Returns:
+        A dictionary containing discussion details or an error message.
+    """
+    print(f"Fetching details for Discussion #{discussion_number} from {OWNER}/{REPO}")
+    query = """
+    query($owner: String!, $repo: String!, $discussionNumber: Int!) {
+      repository(owner: $owner, name: $repo) {
+        discussion(number: $discussionNumber) {
+          id
+          title
+          body
+          author {
+            login
+          }
+          comments(last: 100) {
+            nodes {
+              author {
+                login
+              }
+              body
+              createdAt
+            }
+          }
+          labels(last: 10) {
+            nodes {
+              name
+            }
+          }
+        }
+      }
+    }
+    """
+    variables = {"owner": OWNER, "repo": REPO, "discussionNumber": discussion_number}
 
-GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
-if not GITHUB_TOKEN:
-    raise ValueError("GITHUB_TOKEN environment variable not set")
+    try:
+        response = run_graphql_query(query, variables)
+        if "errors" in response:
+            return error_response(str(response["errors"]))
 
-GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY")
-if not GOOGLE_API_KEY:
-    raise ValueError("GOOGLE_API_KEY environment variable not set")
+        discussion = response.get("data", {}).get("repository", {}).get("discussion")
+        if not discussion:
+            return error_response(f"Discussion #{discussion_number} not found.")
 
-OWNER = os.getenv("OWNER")
-REPO = os.getenv("REPO")
-EVENT_NAME = os.getenv("EVENT_NAME")
-DISCUSSION_NUMBER = os.getenv("DISCUSSION_NUMBER")
+        return {"status": "success", "discussion": discussion}
+    except Exception as e:
+        return error_response(str(e))
 
-IS_INTERACTIVE = os.environ.get("INTERACTIVE", "0").lower() in ["true", "1"]
-TEAM_NAME = "Universal-Commerce-Protocol/maintainers"
+def add_label_to_discussion(discussion_id: str, label_name: str) -> dict[str, Any]:
+    """Adds a label to a discussion.
+
+    Note: This requires fetching the Label ID first if using GraphQL mutations,
+    so we'll use the REST API via the repository's issues endpoint as discussions
+    share labels with issues.
+
+    Args:
+        discussion_id: The GraphQL ID of the discussion (not used in REST but kept for agent signature).
+        label_name: The name of the label to add (e.g., 'needs-review').
+
+    Returns:
+        A success or error status.
+    """
+    # We need the discussion NUMBER to use REST. Since the agent might only have the ID,
+    # we'll assume the context provides enough or we use a mutation.
+    # Actually, let's use the REST API with OWNER/REPO/DISCUSSION_NUMBER if available,
+    # or a GraphQL mutation if we have the ID.
+
+    print(f"Attempting to add label '{label_name}' to Discussion {discussion_id}")
+
+    # GitHub Discussions labels can be managed via the 'addLabelsToLabelable' mutation.
+    # But first we need the label ID. To keep it simple and robust, we use REST
+    # using the discussion number from environment if discussion_id isn't easily mapped.
+
+    from discussion_moderation_agent.settings import DISCUSSION_NUMBER
+    pr_or_disc_num = DISCUSSION_NUMBER # Fallback
+
+    mutation = """
+    mutation($labelableId: ID!, $labelIds: [ID!]!) {
+      addLabelsToLabelable(input: {labelableId: $labelableId, labelIds: $labelIds}) {
+        labelable {
+          ... on Discussion {
+            labels(last: 10) {
+              nodes {
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+    # To get Label ID from Name
+    label_query = """
+    query($owner: String!, $repo: String!) {
+      repository(owner: $owner, name: $repo) {
+        labels(first: 100) {
+          nodes {
+            id
+            name
+          }
+        }
+      }
+    }
+    """
+    try:
+        label_resp = run_graphql_query(label_query, {"owner": OWNER, "repo": REPO})
+        labels = label_resp.get("data", {}).get("repository", {}).get("labels", {}).get("nodes", [])
+        label_id = next((l["id"] for l in labels if l["name"].lower() == label_name.lower()), None)
+
+        if not label_id:
+            return error_response(f"Label '{label_name}' not found in repository.")
+
+        mutation_vars = {"labelableId": discussion_id, "labelIds": [label_id]}
+        run_graphql_query(mutation, mutation_vars)
+        return {"status": "success", "label": label_name}
+    except Exception as e:
+        return error_response(str(e))

--- a/agents/discussion_moderation_agent/utils.py
+++ b/agents/discussion_moderation_agent/utils.py
@@ -1,0 +1,88 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from typing import Any
+
+from discussion_moderation_agent.settings import GITHUB_GRAPHQL_URL
+from discussion_moderation_agent.settings import GITHUB_TOKEN
+from google.adk.agents.run_config import RunConfig
+from google.adk.runners import Runner
+from google.genai import types
+import requests
+from tenacity import retry
+from tenacity import retry_if_exception_type
+from tenacity import stop_after_attempt
+from tenacity import wait_fixed
+
+headers = {
+    "Authorization": f"token {GITHUB_TOKEN}",
+    "Accept": "application/vnd.github.v3+json",
+}
+
+
+def error_response(error_message: str) -> dict[str, Any]:
+    return {"status": "error", "error_message": error_message}
+
+
+@retry(
+    retry=retry_if_exception_type(requests.exceptions.RequestException),
+    stop=stop_after_attempt(3),
+    wait=wait_fixed(2),
+)
+def run_graphql_query(query: str, variables: dict[str, Any]) -> dict[str, Any]:
+    """Executes a GraphQL query."""
+    payload = {"query": query, "variables": variables}
+    response = requests.post(
+        GITHUB_GRAPHQL_URL, headers=headers, json=payload, timeout=60
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def parse_number_string(number_str: str | None, default_value: int = 0) -> int:
+    """Parse a number from the given string."""
+    if not number_str:
+        return default_value
+
+    try:
+        return int(number_str)
+    except ValueError:
+        print(
+            f"Warning: Invalid number string: {number_str}. Defaulting to"
+            f" {default_value}.",
+            file=sys.stderr,
+        )
+        return default_value
+
+
+async def call_agent_async(
+    runner: Runner, user_id: str, session_id: str, prompt: str
+) -> str:
+    """Call the agent asynchronously with the user's prompt."""
+    content = types.Content(role="user", parts=[types.Part.from_text(text=prompt)])
+
+    final_response_text = ""
+    async for event in runner.run_async(
+        user_id=user_id,
+        session_id=session_id,
+        new_message=content,
+        run_config=RunConfig(save_input_blobs_as_artifacts=False),
+    ):
+        if event.content and event.content.parts:
+            if text := "".join(part.text or "" for part in event.content.parts):
+                if event.author != "user":
+                    final_response_text += text
+
+    return final_response_text


### PR DESCRIPTION
**Description**

This PR enhances the discussion_moderation_agent by adding a fourth triage trigger: Stalled Q&A detection.


**Key Updates:**
   * Stalled Q&A Trigger: The agent now monitors Q&A discussions. If a discussion is in an answerable category, has no accepted answer, and has remained inactive for
     over one month, it is automatically flagged with the needs-review label.
   * GraphQL Query Enhancement: Updated the data fetching logic to include category metadata (isAnswerable) and answer status, providing the agent with the necessary
     context to identify stalled threads.
   * Temporal Awareness: Included the current date in the agent's prompt to ensure accurate duration calculations for inactivity.

**Category (Required)**


   - [ ] Core Protocol
   - [ ] Governance/Contributing
   - [ ] Capability
   - [ ] Documentation
   - [x] Infrastructure: CI/CD, Linters, or build scripts.
   - [ ] Maintenance
   - [ ] SDK
   - [ ] Samples / Conformance

**Checklist**


   - [x] I have followed the [Contributing Guide (https://github.com/agentic-commerce/ucp/blob/main/CONTRIBUTING.md).
   - [ ] I have updated the documentation (if applicable).
   - [x] My changes pass all local linting and formatting checks.