### PR TITLE
ci: support optional pr-number and commit-sha in reusable governance + run on draft PRs

### DIFF
--- a/.github/workflows/reusable-governance.yml
+++ b/.github/workflows/reusable-governance.yml
@@ -21,6 +21,14 @@ on:
         required: false
         type: string
         description: "Optional path to the governance rules configuration file (e.g., .github-central/org-tools/governance/rules/python-sdk-rules.yml). If not provided, resolved via --repo mapping."
+      pr-number:
+        required: false
+        type: number
+        description: "Optional PR number. Falls back to pull_request context if not provided."
+      commit-sha:
+        required: false
+        type: string
+        description: "Optional commit SHA. Falls back to pull_request context if not provided."
     secrets:
       ORG_READ_TOKEN:
         required: true
@@ -54,6 +62,17 @@ jobs:
         run: |
           set +e
 
+          # Resolve PR number (input vs event fallback)
+          PR_NUMBER="${{ inputs.pr-number }}"
+          if [ -z "$PR_NUMBER" ]; then
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+          fi
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error::PR number could not be resolved."
+            exit 1
+          fi
+
           RULES_FILE_ARG=""
           if [ -n "${{ inputs.rules-file }}" ]; then
             RULES_FILE_ARG="--rules-file ${{ inputs.rules-file }}"
@@ -63,7 +82,7 @@ jobs:
             --token "${{ secrets.ORG_READ_TOKEN }}" \
             --org "${{ github.repository_owner }}" \
             --repo "${{ github.repository }}" \
-            --pr "${{ github.event.pull_request.number }}" \
+            --pr "$PR_NUMBER" \
             $RULES_FILE_ARG
 
 
@@ -108,11 +127,25 @@ jobs:
             // Construct the exact URL to the current GitHub Actions workflow run logs
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
+            // Resolve SHA (input vs event fallback)
+            let sha = '${{ inputs.commit-sha }}';
+            if (!sha) {
+              sha = context.payload.pull_request ? context.payload.pull_request.head.sha : null;
+            }
+            if (!sha && context.payload.workflow_run) {
+              sha = context.payload.workflow_run.head_sha;
+            }
+
+            if (!sha) {
+              core.setFailed('SHA could not be resolved.');
+              return;
+            }
+
             // Post the status to the specific commit hash
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha: context.payload.pull_request.head.sha,
+              sha: sha,
               state: state,
               context: 'Governance / Approvals',
               description: description,

--- a/.github/workflows/reusable-governance.yml
+++ b/.github/workflows/reusable-governance.yml
@@ -38,7 +38,6 @@ jobs:
   evaluate:
     name: Approvals
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
     steps:
       # 1. Check out the caller repository (the PR code)
       - name: Check out PR code


### PR DESCRIPTION
# Description

This PR updates the `reusable-governance.yml` workflow to accept optional `pr-number` and `commit-sha` inputs. If these inputs are not provided, it falls back to the default `pull_request` context.

This allows the workflow to be triggered from other events (like `workflow_run` or `repository_dispatch`) where the `pull_request` context might not be directly available, but the PR number and commit SHA are known.

It also allow the governance scripts to run for draft PRs, instead of skipping it.

## Category (Required)

_Please select one or more categories that apply to this change._

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [x] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

None.

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [ ] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.
