### PR TITLE
ci: resolve PR number from commit SHA using gh CLI

### DIFF
--- a/.github/workflows/reusable-governance.yml
+++ b/.github/workflows/reusable-governance.yml
@@ -85,7 +85,7 @@ jobs:
             if [ -n "$COMMIT_SHA" ] && [ "$COMMIT_SHA" != "null" ]; then
               echo "Attempting to resolve PR number for SHA $COMMIT_SHA..."
               export GH_TOKEN="${{ secrets.ORG_READ_TOKEN }}"
-              PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --commit "$COMMIT_SHA" --state all --json number --jq '.[0].number' 2>/dev/null)
+              PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --search "$COMMIT_SHA" --state all --json number --jq '.[0].number' 2>/dev/null)
               echo "Resolved PR_NUMBER from gh CLI: '$PR_NUMBER'"
             fi
           fi

--- a/.github/workflows/reusable-governance.yml
+++ b/.github/workflows/reusable-governance.yml
@@ -73,6 +73,24 @@ jobs:
           echo "Debug: Resolved PR_NUMBER is '$PR_NUMBER'"
 
           if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ] || [ "$PR_NUMBER" = "0" ]; then
+            # Try to resolve from commit SHA using gh CLI
+            COMMIT_SHA="${{ inputs.commit-sha }}"
+            if [ -z "$COMMIT_SHA" ] || [ "$COMMIT_SHA" = "null" ]; then
+              COMMIT_SHA="${{ github.event.pull_request.head.sha }}"
+            fi
+            if [ -z "$COMMIT_SHA" ] || [ "$COMMIT_SHA" = "null" ]; then
+              COMMIT_SHA="${{ github.event.workflow_run.head_sha }}"
+            fi
+
+            if [ -n "$COMMIT_SHA" ] && [ "$COMMIT_SHA" != "null" ]; then
+              echo "Attempting to resolve PR number for SHA $COMMIT_SHA..."
+              export GH_TOKEN="${{ secrets.ORG_READ_TOKEN }}"
+              PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --commit "$COMMIT_SHA" --state all --json number --jq '.[0].number' 2>/dev/null)
+              echo "Resolved PR_NUMBER from gh CLI: '$PR_NUMBER'"
+            fi
+          fi
+
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ] || [ "$PR_NUMBER" = "0" ]; then
             echo "::error::PR number could not be resolved."
             exit 1
           fi


### PR DESCRIPTION
# Description

This PR updates the central `reusable-governance.yml` workflow to resolve the PR number from the commit SHA using the `gh` CLI if it cannot be resolved from the event context.

This is necessary because for workflows triggered by `workflow_run` where the triggering workflow was run from a fork, the `github.event.workflow_run.pull_requests` array is empty due to GitHub security policies, preventing the caller workflow from resolving the PR number.

Resolving it from the commit SHA on the base repository allows us to support external contributors' PRs.

## Category (Required)

_Please select one or more categories that apply to this change._

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [x] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

None.

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [ ] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

TAG=agy
CONV=1ef97e2b-e6b6-4be9-9bae-dfc6609dd7c1
