### PR TITLE
ci: change pr-number input type to string

### DIFF
--- a/.github/workflows/reusable-governance.yml
+++ b/.github/workflows/reusable-governance.yml
@@ -23,7 +23,7 @@ on:
         description: "Optional path to the governance rules configuration file (e.g., .github-central/org-tools/governance/rules/python-sdk-rules.yml). If not provided, resolved via --repo mapping."
       pr-number:
         required: false
-        type: number
+        type: string
         description: "Optional PR number. Falls back to pull_request context if not provided."
       commit-sha:
         required: false


### PR DESCRIPTION
# Description

This PR changes the `pr-number` input type from `number` to `string` in the `reusable-governance.yml` workflow.

This is necessary because when the workflow is called from a context where the PR number is not available (like `workflow_run`), GHA expressions like `${{ github.event.pull_request.number }}` evaluate to empty string `''`.
If the input type is `number`, GHA rejects the empty string with a parser error:
`Unexpected value ''`

Changing the input type to `string` allows GHA to accept the empty string. The central workflow's fallback logic already handles empty/null strings and will correctly attempt to resolve the PR number from the commit SHA.

## Category (Required)

_Please select one or more categories that apply to this change._

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [x] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [x] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

None.

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [ ] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.


