### PR TITLE
chore: apply needs-triage label only when no other label is applied

### DIFF
--- a/org-tools/triage/scripts/triage_logic.py
+++ b/org-tools/triage/scripts/triage_logic.py
@@ -28,7 +28,6 @@ import github
 logger = logging.getLogger("triage")
 
 TARGET_LABEL = "status:needs-triage"
-SKIP_LABELS = {"status:backlog", "status:stale", "status:under-review"}
 
 
 def log_error(message: str, *args) -> None:
@@ -82,13 +81,8 @@ class TriageLabeler:
         """
         logger.info("\nProcessing Repository: %s", self.repo.full_name)
 
-        # Construct query to filter out drafts and labeled/skip PRs at the API level.
-        exclude_labels_query = " ".join(
-            f"-label:{label}" for label in [TARGET_LABEL] + list(SKIP_LABELS)
-        )
-        query = (
-            f"is:pr is:open -is:draft {exclude_labels_query} repo:{self.repo.full_name}"
-        )
+        # Construct query to find PRs with no labels.
+        query = f"is:pr is:open -is:draft no:label repo:{self.repo.full_name}"
         logger.info("  Search Query: %s", query)
 
         try:
@@ -160,12 +154,9 @@ class TriageLabeler:
             )
             return False
 
-        for skip_label in SKIP_LABELS:
-            if skip_label in labels:
-                logger.info(
-                    "Skipping: PR #%s has skip label '%s'.", pull.number, skip_label
-                )
-                return False
+        if len(labels) > 0:
+            logger.info("Skipping: PR #%s has other labels: %s", pull.number, labels)
+            return False
 
         return True
 

--- a/org-tools/triage/tests/test_triage_logic.py
+++ b/org-tools/triage/tests/test_triage_logic.py
@@ -144,6 +144,22 @@ class TestTriageLabelerPRRules(unittest.TestCase):
 
         self.assertFalse(self.labeler._is_eligible_for_triage(pr))
 
+    def test_pr_with_generic_label_should_not_be_triaged(self):
+        """Test that a PR carrying any generic label returns False."""
+        pr = Mock(spec=github.PullRequest.PullRequest)
+        pr.number = 1
+        pr.state = "open"
+        pr.draft = False
+        pr.requested_reviewers = []
+        pr.requested_teams = []
+        pr.get_reviews.return_value.totalCount = 0
+
+        mock_label = Mock()
+        mock_label.name = "some-random-label"
+        pr.labels = [mock_label]
+
+        self.assertFalse(self.labeler._is_eligible_for_triage(pr))
+
 
 class TestTriageLabelerLabelApplication(unittest.TestCase):
     """Tests for applying the 'status:needs-triage' label to PRs on GitHub."""
@@ -269,10 +285,7 @@ class TestTriageLabelerBulkExecution(unittest.TestCase):
         self.assertIn("is:pr", query)
         self.assertIn("is:open", query)
         self.assertIn("-is:draft", query)
-        self.assertIn("-label:status:needs-triage", query)
-        self.assertIn("-label:status:backlog", query)
-        self.assertIn("-label:status:stale", query)
-        self.assertIn("-label:status:under-review", query)
+        self.assertIn("no:label", query)
         self.assertIn("repo:mock-org/mock-repo", query)
 
     def test_bulk_triage_raises_runtime_error_on_search_failure(self):


### PR DESCRIPTION
# Description

Modify the triage logic to only apply the `status:needs-triage` label if the PR has no other labels. This prevents clobbering existing classifications and reduces noise.

## Category (Required)

- [x] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
