### PR TITLE
fix: count reviewers who commented in assigned reviewers count

### DIFF
--- a/org-tools/governance/scripts/pr_validator.py
+++ b/org-tools/governance/scripts/pr_validator.py
@@ -291,7 +291,13 @@ class PullRequestValidator:
             else:
                 assigned.add(user)
 
+        # Count reviewers who have submitted reviews (including comments) as actively reviewing
+        for review in pr.reviews:
+            if review.user != pr.author:
+                assigned.add(review.user.lower())
+
         assigned.difference_update(approvers)
+        assigned.discard(pr.author)
         return approvers, assigned
 
     def _evaluate_file_statuses(

--- a/org-tools/governance/tests/test_pr_validator.py
+++ b/org-tools/governance/tests/test_pr_validator.py
@@ -712,6 +712,107 @@ class TestPullRequestValidator(unittest.TestCase):
         self.assertFalse(status.is_satisfied)
         self.assertEqual(status.approvers, ["maint1"])
 
+    def test_commented_reviewer_counts_towards_assigned_count(self):
+        """Test that a reviewer who added comments is counted in assigned_count."""
+        # Setup hierarchy and config requiring 2 approvals from maintainers
+        hierarchy = {
+            "maintainers": Team(name="maintainers", level=2),
+        }
+        rules = [
+            GovernanceRule(
+                name="Test Rule",
+                patterns=["*"],
+                requires_all=[
+                    RuleRequirement(min_approvals=2, min_team=hierarchy["maintainers"])
+                ],
+            )
+        ]
+        config = GovernanceConfig(
+            teams=hierarchy,
+            rules=rules,
+            fallback=[],
+            proxy_reviewers=set(),
+        )
+        memberships = TeamMemberships.create(
+            members_by_team={
+                "maintainers": {"maint1", "maint2", "maint3"},
+            },
+            teams=hierarchy,
+        )
+        validator = PullRequestValidator(config, memberships)
+
+        # maint1 approved, maint2 commented (no longer in review_requests on GitHub)
+        pr = PullRequest(
+            number=1,
+            author="author1",
+            is_draft=False,
+            changed_files=["file.txt"],
+            reviews=[
+                Review(user="maint1", state=ReviewState.APPROVED),
+                Review(user="maint2", state=ReviewState.COMMENTED),
+            ],
+            assigned_user_names=[],
+        )
+
+        res = validator.validate(pr)
+        self.assertFalse(res.is_mergeable)
+        self.assertEqual(res.error, ValidationErrorReason.INSUFFICIENT_APPROVALS)
+
+        self.assertEqual(len(res.requirement_statuses), 1)
+        status = res.requirement_statuses[0]
+        self.assertEqual(status.approved_count, 1)
+        self.assertEqual(status.assigned_count, 1)  # maint2 who commented is counted
+        self.assertFalse(status.is_satisfied)
+        self.assertEqual(status.approvers, ["maint1"])
+
+    def test_author_comments_not_counted_in_assigned(self):
+        """Test that PR author comments do not count towards assigned_count."""
+        hierarchy = {
+            "maintainers": Team(name="maintainers", level=2),
+        }
+        rules = [
+            GovernanceRule(
+                name="Test Rule",
+                patterns=["*"],
+                requires_all=[
+                    RuleRequirement(min_approvals=2, min_team=hierarchy["maintainers"])
+                ],
+            )
+        ]
+        config = GovernanceConfig(
+            teams=hierarchy,
+            rules=rules,
+            fallback=[],
+            proxy_reviewers=set(),
+        )
+        # Author is also a maintainer
+        memberships = TeamMemberships.create(
+            members_by_team={
+                "maintainers": {"author1", "maint1", "maint2"},
+            },
+            teams=hierarchy,
+        )
+        validator = PullRequestValidator(config, memberships)
+
+        pr = PullRequest(
+            number=1,
+            author="author1",
+            is_draft=False,
+            changed_files=["file.txt"],
+            reviews=[
+                Review(user="author1", state=ReviewState.COMMENTED),
+                Review(user="maint1", state=ReviewState.APPROVED),
+            ],
+            assigned_user_names=[],
+        )
+
+        res = validator.validate(pr)
+        self.assertFalse(res.is_mergeable)
+        status = res.requirement_statuses[0]
+        self.assertEqual(status.approved_count, 1)
+        self.assertEqual(status.assigned_count, 0)  # Author comments do not count
+        self.assertEqual(status.approvers, ["maint1"])
+
 
 class TestFetchTeamMemberships(unittest.TestCase):
     """Tests for GitHubClient.fetch_team_memberships method."""


### PR DESCRIPTION
# Description

When an assigned reviewer submits a comment review on GitHub, GitHub automatically fulfills their review request and removes them from the PR requested reviewers list (`pr.get_review_requests()`). Because `pr_models.py` filters out non-actionable review states like `COMMENTED` from `latest_actionable_reviews_by_username`, these reviewers previously disappeared from the `assigned` list entirely, causing the governance report to report `0 eligible reviewers assigned` even when authorized reviewers were actively reviewing and commenting.

This change includes non-author reviewers who have submitted reviews (such as comments) in the `assigned` reviewer set (unless they have already approved), ensuring the governance validation report accurately reflects active reviewers in `assigned_count`.

## Category (Required)

_Please select one or more categories that apply to this change._

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [x] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [x] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

None

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [ ] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

```
============================== 61 passed in 0.15s ==============================
```
